### PR TITLE
Add Root Route (/) for Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,92 @@
 .venv/
 cd path/to/frostiq
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# SQLite database files
+*.db
+*.sqlite3
+
+# Distribution / packaging
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env/
+.venv/
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# Pyre type checker
+.pyre/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pytest
+.pytest_cache/
+
+# Environments
+.env
+*.env
+
+# VSCode
+.vscode/
+
+# Local dev
+*.log
+*.bak
+*.swp
+.DS_Store
+Thumbs.db
+.idea/
+
+# Mac/Linux system files
+*.DS_Store
+
+# Windows system files
+ehthumbs.db
+Icon?
+desktop.ini
+
+# Ignore compiled routers or folders
+**/routers/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.venv/
-cd path/to/frostiq
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/BakeryBackend/main.py
+++ b/BakeryBackend/main.py
@@ -5,7 +5,9 @@ from routers import favorites
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Bakery Backend with Favorites")
-
+@app.get("/")
+async def root():
+    return {"message": "Welcome to the Bakery Backend API!"}
 
 app.include_router(favorites.router)
 


### PR DESCRIPTION
This PR introduces a root route ("/") to the FastAPI backend, enabling a basic health check or greeting endpoint. It helps confirm that the API is running successfully and is accessible at the root URL.

Changes Made:
Added a GET / endpoint in main.py that returns a welcome message.

Why This Is Needed
Acts as a health check route to confirm the backend is up and responsive

Provides a friendly greeting for developers and users

 Useful for CI/CD and monitoring systems to ping the server root

Prevents 404 error when accessing the base URL

Issue number #12 